### PR TITLE
fix(team): Correctly refresh on deleted team.

### DIFF
--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -128,7 +128,7 @@ func (d *teamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	})
 
 	// Use Forgejo client to get team by name
-	team, diags := getOrgTeamByName(
+	team, diags := getOrgTeamByNameOrError(
 		ctx,
 		d.client,
 		data.OrganizationID,
@@ -223,13 +223,30 @@ func getOrgTeamByName(ctx context.Context, client *forgejo.Client, orgID types.I
 		return t.Name == teamName.ValueString()
 	})
 	if idx == -1 {
-		diags.AddError(
-			"Unable to find team by name",
-			fmt.Sprintf("Team with name %s not found", teamName.String()),
-		)
-
 		return nil, diags
 	}
 
 	return teams[idx], diags
+}
+
+func getOrgTeamByNameOrError(ctx context.Context, client *forgejo.Client, orgID types.Int64, teamName types.String) (*forgejo.Team, diag.Diagnostics) {
+	team, diags := getOrgTeamByName(ctx, client, orgID, teamName)
+	if team == nil && diags == nil {
+		diags.AddError(
+			"Unable to find team by name",
+			fmt.Sprintf("Team with name %s not found", teamName.String()),
+		)
+		return nil, diags
+	}
+	return team, diags
+}
+
+func hasOrgTeamByName(ctx context.Context, client *forgejo.Client, orgID types.Int64, teamName types.String) (bool, diag.Diagnostics) {
+	var hasTeam bool
+	team, diags := getOrgTeamByName(ctx, client, orgID, teamName)
+	if diags == nil {
+		hasTeam = team != nil
+		return hasTeam, diags
+	}
+	return hasTeam, diags
 }

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -290,6 +290,22 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		"organization_id": data.OrganizationID.ValueInt64(),
 	})
 
+	hasTeam, diags := hasOrgTeamByName(
+		ctx,
+		r.client,
+		data.OrganizationID,
+		data.Name,
+	)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	if !hasTeam {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	// Use Forgejo client to read existing team
 	team, diags := getOrgTeamByName(
 		ctx,


### PR DESCRIPTION
When the team was removed within Forgejo, the provider should read that on refresh, instead of erroring.

Fixes #111.