### PR TITLE
fix: use ListMyOrgs instead of AdminListOrgs for non-admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following API token permissions are required:
 - `write:repository`
 - `write:user`
 
-Optionally, for administrative privileges (required to manage users, user repositories, user SSH keys, teams, and organization action secrets/variables):
+Optionally, for administrative privileges (required to manage users, user repositories, and user SSH keys):
 
 - `write:admin`
 
@@ -259,7 +259,7 @@ Re-generate the API token used for authentication, and make sure to select the f
 - `write:organization`
 - `write:repository`
 - `write:user`
-- Optional, for managing users, user repositories, user SSH keys, teams, and organization action secrets/variables: `write:admin`
+- Optional, for managing users, user repositories, and user SSH keys: `write:admin`
 
 ## Developing & Contributing to the Provider
 

--- a/docs/resources/organization_action_secret.md
+++ b/docs/resources/organization_action_secret.md
@@ -4,14 +4,14 @@ page_title: "forgejo_organization_action_secret Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo organization action secret resource.
-  Note: The authenticated user must be a member of the managed organization(s)!
+  Note: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 ---
 
 # forgejo_organization_action_secret (Resource)
 
 Forgejo organization action secret resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 
 ## Example Usage
 

--- a/docs/resources/organization_action_secret.md
+++ b/docs/resources/organization_action_secret.md
@@ -4,14 +4,14 @@ page_title: "forgejo_organization_action_secret Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo organization action secret resource.
-  Note: Managing organization action secrets requires administrative privileges!
+  Note: The authenticated user must be a member of the managed organization(s)!
 ---
 
 # forgejo_organization_action_secret (Resource)
 
 Forgejo organization action secret resource.
 
-**Note**: Managing organization action secrets requires administrative privileges!
+**Note**: The authenticated user must be a member of the managed organization(s)!
 
 ## Example Usage
 

--- a/docs/resources/organization_action_variable.md
+++ b/docs/resources/organization_action_variable.md
@@ -4,14 +4,14 @@ page_title: "forgejo_organization_action_variable Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo organization action variable resource.
-  Note: Managing organization action variables requires administrative privileges!
+  Note: The authenticated user must be a member of the managed organization(s)!
 ---
 
 # forgejo_organization_action_variable (Resource)
 
 Forgejo organization action variable resource.
 
-**Note**: Managing organization action variables requires administrative privileges!
+**Note**: The authenticated user must be a member of the managed organization(s)!
 
 ## Example Usage
 

--- a/docs/resources/organization_action_variable.md
+++ b/docs/resources/organization_action_variable.md
@@ -4,14 +4,14 @@ page_title: "forgejo_organization_action_variable Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo organization action variable resource.
-  Note: The authenticated user must be a member of the managed organization(s)!
+  Note: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 ---
 
 # forgejo_organization_action_variable (Resource)
 
 Forgejo organization action variable resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 
 ## Example Usage
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -4,14 +4,14 @@ page_title: "forgejo_team Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo team resource.
-  Note: The authenticated user must be a member of the managed organization(s)!
+  Note: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 ---
 
 # forgejo_team (Resource)
 
 Forgejo team resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!
 
 ## Example Usage
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -4,14 +4,14 @@ page_title: "forgejo_team Resource - forgejo"
 subcategory: ""
 description: |-
   Forgejo team resource.
-  Note: Managing teams requires administrative privileges!
+  Note: The authenticated user must be a member of the managed organization(s)!
 ---
 
 # forgejo_team (Resource)
 
 Forgejo team resource.
 
-**Note**: Managing teams requires administrative privileges!
+**Note**: The authenticated user must be a member of the managed organization(s)!
 
 ## Example Usage
 

--- a/internal/provider/organization_action_secret_resource.go
+++ b/internal/provider/organization_action_secret_resource.go
@@ -71,7 +71,7 @@ func (r *organizationActionSecretResource) Schema(_ context.Context, _ resource.
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo organization action secret resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!`,
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!`,
 
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.Int64Attribute{

--- a/internal/provider/organization_action_secret_resource.go
+++ b/internal/provider/organization_action_secret_resource.go
@@ -71,7 +71,7 @@ func (r *organizationActionSecretResource) Schema(_ context.Context, _ resource.
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo organization action secret resource.
 
-**Note**: Managing organization action secrets requires administrative privileges!`,
+**Note**: The authenticated user must be a member of the managed organization(s)!`,
 
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.Int64Attribute{

--- a/internal/provider/organization_action_variable_resource.go
+++ b/internal/provider/organization_action_variable_resource.go
@@ -65,7 +65,7 @@ func (r *organizationActionVariableResource) Schema(_ context.Context, _ resourc
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo organization action variable resource.
 
-**Note**: Managing organization action variables requires administrative privileges!`,
+**Note**: The authenticated user must be a member of the managed organization(s)!`,
 
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.Int64Attribute{

--- a/internal/provider/organization_action_variable_resource.go
+++ b/internal/provider/organization_action_variable_resource.go
@@ -65,7 +65,7 @@ func (r *organizationActionVariableResource) Schema(_ context.Context, _ resourc
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo organization action variable resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!`,
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!`,
 
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.Int64Attribute{

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -161,8 +161,8 @@ func getOrganizationByID(ctx context.Context, client *forgejo.Client, id int64) 
 	})
 
 	// Use Forgejo client to list organizations
-	orgs, res, err := client.AdminListOrgs(
-		forgejo.AdminListOrgsOptions{
+	orgs, res, err := client.ListMyOrgs(
+		forgejo.ListOrgsOptions{
 			ListOptions: forgejo.ListOptions{
 				Page: -1,
 			},

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -89,7 +89,7 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo team resource.
 
-**Note**: The authenticated user must be a member of the managed organization(s)!`,
+**Note**: The authenticated user must be a member of the managed organization(s) or have administrative privileges!`,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -89,7 +89,7 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Forgejo team resource.
 
-**Note**: Managing teams requires administrative privileges!`,
+**Note**: The authenticated user must be a member of the managed organization(s)!`,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{


### PR DESCRIPTION
`getOrganizationByID()` in `organization_data_source.go` calls `client.AdminListOrgs()`, which requires the `read:admin` token scope. This scope is unavailable to non-site-admin users on shared Forgejo instances like Codeberg, making it impossible to use `forgejo_team`, `forgejo_team_member`, and other resources that depend on `getOrganizationByID()`.

Since users managing org teams are necessarily members of those orgs, `ListMyOrgs()` returns the same results for all practical use cases and only requires the `read:organization` scope.

This change replaces `AdminListOrgs` with `ListMyOrgs` and updates the options type from `AdminListOrgsOptions` to `ListOrgsOptions` accordingly.