### PR TITLE
feat: add import support for forgejo_team resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Each resource defines its own import identifier, which uniquely identifies the r
 | `forgejo_repository`        | `<<<repo_owner>>>/<<<repo_name>>>`              |
 | `forgejo_branch_protection` | `<<<repo_owner>>>/<<<repo_name>>>/<<<branch>>>` |
 | `forgejo_user`              | `<<<login>>>`                                   |
-| `forgejo_team`              | `<<<org>>>/<<<team_name>>>`                     |
+| `forgejo_team`              | `<<<org_name>>>/<<<team_name>>>`                     |
 
 Refer to the `examples/` directory for more import examples.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Each resource defines its own import identifier, which uniquely identifies the r
 | `forgejo_repository`        | `<<<repo_owner>>>/<<<repo_name>>>`              |
 | `forgejo_branch_protection` | `<<<repo_owner>>>/<<<repo_name>>>/<<<branch>>>` |
 | `forgejo_user`              | `<<<login>>>`                                   |
+| `forgejo_team`              | `<<<org>>>/<<<team_name>>>`                     |
 
 Refer to the `examples/` directory for more import examples.
 

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -448,23 +448,38 @@ func (r *teamResource) ImportState(ctx context.Context, req resource.ImportState
 
 	var state teamResourceModel
 
-	teamID, err := strconv.ParseInt(req.ID, 10, 64)
-	if err != nil {
+	// Parse import identifier
+	cmp := strings.Split(req.ID, "/")
+	if len(cmp) != 2 {
 		resp.Diagnostics.AddError(
 			"Unable to parse import identifier",
 			fmt.Sprintf(
-				"Expected numeric team ID, got: '%s'",
+				"Expected import identifier with format: 'org/team', got: '%s'",
 				req.ID,
 			),
 		)
 
 		return
 	}
+	orgName, teamName := cmp[0], cmp[1]
 
-	team, diags := getOrgTeamByID(
+	// Use Forgejo client to get organization
+	org, diags := getOrganizationByName(
 		ctx,
 		r.client,
-		teamID,
+		orgName,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Use Forgejo client to get team
+	team, diags := getOrgTeamByName(
+		ctx,
+		r.client,
+		org.ID,
+		teamName,
 	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -463,22 +463,11 @@ func (r *teamResource) ImportState(ctx context.Context, req resource.ImportState
 	}
 	orgName, teamName := cmp[0], cmp[1]
 
-	// Use Forgejo client to get organization
-	org, diags := getOrganizationByName(
-		ctx,
-		r.client,
-		orgName,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	// Use Forgejo client to get team
 	team, diags := getOrgTeamByName(
 		ctx,
 		r.client,
-		org.ID,
+		orgName,
 		teamName,
 	)
 	resp.Diagnostics.Append(diags...)
@@ -486,12 +475,14 @@ func (r *teamResource) ImportState(ctx context.Context, req resource.ImportState
 		return
 	}
 
+	// Map response body to model
 	diags = state.from(team, ctx)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Save data into Terraform state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -25,8 +26,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &teamResource{}
-	_ resource.ResourceWithConfigure = &teamResource{}
+	_ resource.Resource                = &teamResource{}
+	_ resource.ResourceWithConfigure   = &teamResource{}
+	_ resource.ResourceWithImportState = &teamResource{}
 )
 
 // teamResource is the resource implementation.
@@ -438,6 +440,45 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 		return
 	}
+}
+
+// ImportState reads an existing resource and adds it to Terraform state on success.
+func (r *teamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer un(trace(ctx, "Import team resource"))
+
+	var state teamResourceModel
+
+	teamID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to parse import identifier",
+			fmt.Sprintf(
+				"Expected numeric team ID, got: '%s'",
+				req.ID,
+			),
+		)
+
+		return
+	}
+
+	team, diags := getOrgTeamByID(
+		ctx,
+		r.client,
+		teamID,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = state.from(team, ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // NewTeamResource is a helper function to simplify the provider implementation.

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -148,6 +148,34 @@ resource "forgejo_team" "test_by_name2" {
 }`,
 				ExpectError: regexp.MustCompile("Input validation error: team already exists"),
 			},
+			// Import testing (invalid identifier)
+			{
+				ResourceName:  "forgejo_team.test_by_name",
+				ImportState:   true,
+				ImportStateId: "invalid",
+				ExpectError:   regexp.MustCompile("Expected import identifier with format: 'org/team', got: 'invalid'"),
+			},
+			// Import testing (non-existent org)
+			{
+				ResourceName:  "forgejo_team.test_by_name",
+				ImportState:   true,
+				ImportStateId: "non-existent/test_team_by_name",
+				ExpectError:   regexp.MustCompile("Organization with name 'non-existent' not found"),
+			},
+			// Import testing (non-existent team)
+			{
+				ResourceName:  "forgejo_team.test_by_name",
+				ImportState:   true,
+				ImportStateId: "team_test_org/non-existent",
+				ExpectError:   regexp.MustCompile("Team with name 'non-existent' not found"),
+			},
+			// Import testing
+			{
+				ResourceName:      "forgejo_team.test_by_name",
+				ImportState:       true,
+				ImportStateId:     "team_test_org/test_team_by_name",
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: providerConfig + `

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -784,10 +784,6 @@ func (r *userResource) ImportState(ctx context.Context, req resource.ImportState
 
 	var state userResourceModel
 
-	tflog.Info(ctx, "Read user", map[string]any{
-		"username": req.ID,
-	})
-
 	// Use Forgejo client to get user
 	usr, diags := getUserByName(
 		ctx,


### PR DESCRIPTION
Implements `ImportState` for the `forgejo_team` resource, allowing existing teams to be imported into state using their numeric team ID:

```bash
tofu import forgejo_team.example 12345
```

The implementation follows the same pattern as `forgejo_repository` and `forgejo_user` (parses the ID, calls `getOrgTeamByID`, and maps the result to the resource model)