### PR TITLE
ci: update latest terraform version to 1.15.*

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,9 +80,9 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - "1.12.*"
-          - "1.13.*"
+          - "1.15.*"
           - "1.14.*"
+          - "1.13.*"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Purpose

- Removes 1.12.* version
- Adds 1.15.* version
- Changes the sort order of the terraform variables to match opentofu

Relates to: https://github.com/svalabs/terraform-provider-forgejo/issues/136 