### PR TITLE
fix(repository): canonicalize mirror intervals

### DIFF
--- a/internal/provider/mirror_interval.go
+++ b/internal/provider/mirror_interval.go
@@ -1,0 +1,27 @@
+package provider
+
+import (
+	"fmt"
+	"time"
+)
+
+// canonicalizeMirrorInterval converts Forgejo's duration representation to
+// the hour-prefixed format accepted by the Terraform resource validator.
+// Forgejo omits a zero-hour prefix, returning "10m0s" for "0h10m0s".
+func canonicalizeMirrorInterval(value string) string {
+	if value == "" {
+		return value
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration < 0 || duration%time.Second != 0 {
+		return value
+	}
+
+	seconds := int64(duration / time.Second)
+	hours := seconds / 3600
+	minutes := (seconds % 3600) / 60
+	remainingSeconds := seconds % 60
+
+	return fmt.Sprintf("%dh%dm%ds", hours, minutes, remainingSeconds)
+}

--- a/internal/provider/mirror_interval_test.go
+++ b/internal/provider/mirror_interval_test.go
@@ -1,0 +1,24 @@
+package provider
+
+import "testing"
+
+func TestCanonicalizeMirrorInterval(t *testing.T) {
+	tests := map[string]string{
+		"":        "",
+		"10m0s":   "0h10m0s",
+		"0h10m0s": "0h10m0s",
+		"1h10m0s": "1h10m0s",
+		"90m0s":   "1h30m0s",
+		"invalid": "invalid",
+		"-10m0s":  "-10m0s",
+		"1.5s":    "1.5s",
+	}
+
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			if actual := canonicalizeMirrorInterval(input); actual != expected {
+				t.Fatalf("canonicalizeMirrorInterval(%q) = %q, want %q", input, actual, expected)
+			}
+		})
+	}
+}

--- a/internal/provider/repository_data_source.go
+++ b/internal/provider/repository_data_source.go
@@ -493,7 +493,7 @@ func (d *repositoryDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	data.AllowSquash = types.BoolValue(rep.AllowSquash)
 	data.AvatarURL = types.StringValue(rep.AvatarURL)
 	data.Internal = types.BoolValue(rep.Internal)
-	data.MirrorInterval = types.StringValue(rep.MirrorInterval)
+	data.MirrorInterval = types.StringValue(canonicalizeMirrorInterval(rep.MirrorInterval))
 	data.MirrorUpdated = types.StringValue(rep.MirrorUpdated.Format(time.RFC3339))
 	data.DefaultMergeStyle = types.StringValue(string(rep.DefaultMergeStyle))
 

--- a/internal/provider/repository_resource.go
+++ b/internal/provider/repository_resource.go
@@ -178,7 +178,7 @@ func (m *repositoryResourceModel) from(r *forgejo.Repository) {
 	m.HasActions = types.BoolValue(r.HasActions)
 	m.AvatarURL = types.StringValue(r.AvatarURL)
 	m.Internal = types.BoolValue(r.Internal)
-	m.MirrorInterval = types.StringValue(r.MirrorInterval)
+	m.MirrorInterval = types.StringValue(canonicalizeMirrorInterval(r.MirrorInterval))
 	m.MirrorUpdated = types.StringValue(r.MirrorUpdated.Format(time.RFC3339))
 
 	if m.HasPullRequests.ValueBool() {


### PR DESCRIPTION
## Problem

Forgejo normalizes mirror intervals such as `0h10m0s` to `10m0s` in the API response. The provider writes that response directly into Terraform state, producing:

```text
Provider produced inconsistent result after apply
.mirror_interval: was cty.StringVal("0h10m0s"), but now cty.StringVal("10m0s")
```

## Fix

Canonicalize API mirror intervals into the provider's hour-prefixed format before writing resource or data-source state. Invalid, negative, fractional, and empty values are preserved unchanged.

## Validation

- `go test ./...`
- `go vet ./...`
- Added unit coverage for zero-hour, multi-hour, invalid, negative, and fractional values.

This PR was prepared with assistance from generative AI; the changes were reviewed and tested by the author.